### PR TITLE
Make command page display when loaded

### DIFF
--- a/source/templates/commands.html.slim
+++ b/source/templates/commands.html.slim
@@ -13,7 +13,7 @@ ruby:
   #tab-content.tab-content
 
     // Pod Command
-    div.tab-pane id="tab_#{parameterize name_space.name}"
+    div.tab-pane id="tab_#{parameterize name_space.name}" class="active"
       h2 = name_space.name
       == link_doc_string name_space.html_description
 


### PR DESCRIPTION
It used to only be shown correctly after having viewed a different
command, and then returned to the command page. This commit makes it
active upon load.

fixes #4
