### PR TITLE
Split "What is a Podfile?" section

### DIFF
--- a/source/using/the-podfile.html.md
+++ b/source/using/the-podfile.html.md
@@ -48,6 +48,7 @@ pod 'AFNetworking', '~> 1.0'
 pod 'Objection', '0.9'
 ```
 
+### Specifying pod versions
 
 > When starting out with a project it is likely that you will want to use the latest version of a Pod. If this is the case, simply omit the version requirements.
 


### PR DESCRIPTION
Added a sub header in order to allow linking directly to the syntax for specifying pod versions.
