### PR TITLE
Add `bundle install` step into process of dev environment setup

### DIFF
--- a/source/contributing/dev-environment.html.md
+++ b/source/contributing/dev-environment.html.md
@@ -23,6 +23,7 @@ $ echo ".rvmrc" >> .git/info/exclude
 # Reload the rvm config by jumping in and out of your dev folder
 # then init & update git submodules and install ruby dependencies using a rake task.
 $ cd .. ; cd -   
+$ bundle install
 $ rake bootstrap 
 ```
 
@@ -33,6 +34,7 @@ $ rake bootstrap
 $ sudo gem install bundler 
 
 # Init & update git submodules and install ruby dependencies using a rake task.
+$ bundle install
 $ rake bootstrap
 ```
 


### PR DESCRIPTION
I was just setting up cocoapods dev environment and have noticed that I had to run `bundle` before `rake bootstrap`.

```
➜  code  git clone git://github.com/CocoaPods/CocoaPods.git
Cloning into 'CocoaPods'...
remote: Counting objects: 29087, done.
remote: Compressing objects: 100% (9918/9918), done.
remote: Total 29087 (delta 18729), reused 28907 (delta 18608)
Receiving objects: 100% (29087/29087), 26.71 MiB | 254.00 KiB/s, done.
Resolving deltas: 100% (18729/18729), done.
Checking connectivity... done.
➜  code  cd CocoaPods
➜  echo "2.0.0-p353" > .ruby-version
➜  CocoaPods git:(master) cd .. && cd -
~/code/CocoaPods
➜  CocoaPods git:(master) rake bootstrap
https://github.com/CocoaPods/CLAide.git (at master) is not yet checked out. Run `bundle install` first.
➜  CocoaPods git:(master) bundle
Fetching https://github.com/CocoaPods/CLAide.git
Cloning into bare repository '/Users/yas/.gem/ruby/2.0.0/cache/bundler/git/CLAide-1f7c26f0e18404ea56d6204dab591f5ec71ac1b9'...
remote: Counting objects: 1792, done.
...
```
