### PR TITLE
Get rid of the "gun" analogy in the FAQ

### DIFF
--- a/source/using/faq.html.md
+++ b/source/using/faq.html.md
@@ -36,7 +36,7 @@ order: 4
 
 ### “CocoaPods is bad for the community, because it makes it too easy for users to add many dependencies.”
 
- This is akin to saying "we should not have cars", as they make us lazy and we forget walking/running. Or "we should not use [IDEs]"(http://programmers.stackexchange.com/questions/39798/being-ide-dependent-how-can-it-harm-me/39809#39809) as they make us bad programmers, who can't code in editor and can't remember syntax. Furthermore, this reasoning applies to basically any means of fetching code (e.g. git) and as such is not a discussion worth having.
+ This is akin to saying "we should not have cars", as they make us lazy and we forget walking/running. Or "we should not use [IDEs](http://programmers.stackexchange.com/questions/39798/being-ide-dependent-how-can-it-harm-me/39809#39809)" as they make us bad programmers, who can't code in editor and can't remember syntax. Furthermore, this reasoning applies to basically any means of fetching code (e.g. git) and as such is not a discussion worth having.
 
   What _is_ worth discussing, however, is informing the user to be responsible. Ironically enough, the original author of CocoaPods is convinced using a lot of dependencies is a really bad idea. For practical advice on how to deal with this, you should read [this blog post](http://www.fngtps.com/2013/a-quick-note-on-minimal-dependencies-in-ruby-on-rails/) by [Manfred Stienstra](http://twitter.com/manfreds).
 


### PR DESCRIPTION
I don't really like Gun analogy here. I think we can do without it. I have made some edits, you can use them or I am sure community can come up with other positive analogies.
