### PR TITLE
Add section about setup to getting-started guide

### DIFF
--- a/source/using/getting-started.html.md
+++ b/source/using/getting-started.html.md
@@ -33,6 +33,14 @@ $ sudo gem install cocoapods
 
 If you encounter any problems during installation, please visit [this](http://guides.cocoapods.org/using/troubleshooting#installing-cocoapods) guide.
 
+### Setup CocoaPods
+
+After you have installed CocoaPods, you must setup the environment before you can install dependencies.
+
+```shell
+$ pod setup
+```
+
 ### Sudo-less installation
 
 If you do *not* want to grant RubyGems admin privileges for this process, you can


### PR DESCRIPTION
Currently none of the CocoaPods documentation references the need to issue "pod setup" before attempting to run "pod install" in a project directory. Running the latter command will fail with an error (No such file or directory - ~/.cocoapods/repos) if setup is not run first. 

I'm not sure if this is a good place for the documentation, but it needs to be mentioned somewhere visibly for new users.
