### PR TITLE
acheived [sic] misspelled.  Should be 'achieved'

### DIFF
--- a/source/making/private-cocoapods.html.md
+++ b/source/making/private-cocoapods.html.md
@@ -64,7 +64,7 @@ source 'URL_TO_REPOSITORY'
 
 ###1. Create a Private Spec Repo
 
-> Create a repo on your server. This can be acheived on Github or on your own server as follows
+> Create a repo on your server. This can be achieved on Github or on your own server as follows
 
 ```shell
 $ cd /opt/git


### PR DESCRIPTION
Noticed that achieved was misspelled on the 'Private Pods' page on guides.  Fixed