### PR TITLE
Update post_install syntax for CocoaPods 0.38

### DIFF
--- a/source/using/the-podfile.html.md
+++ b/source/using/the-podfile.html.md
@@ -36,7 +36,7 @@ target :test do
 end
 
 post_install do |installer|
-    installer.project.targets.each do |target|
+    installer.pods_project.targets.each do |target|
         puts target.name
     end
 end


### PR DESCRIPTION
Update the post_install hook example to `installer.pods_project` from
`installer.project` due to the breaking syntax change in CocoaPods 0.38.

See https://github.com/CocoaPods/CocoaPods/issues/3747 for further
discussion.