### PR TITLE
[WIP] add generation of Dash docsets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,8 @@ gem 'cocoapods-core', '>= 0.36.1'
 gem 'molinillo'
 gem 'netrc'
 
+gem 'sqlite3'
+
 group :development do
   gem 'foreman'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,6 +155,7 @@ GEM
     sprockets-sass (1.2.0)
       sprockets (~> 2.0)
       tilt (~> 1.1)
+    sqlite3 (1.3.10)
     temple (0.6.9)
     thor (0.19.1)
     thread_safe (0.3.5)
@@ -193,7 +194,5 @@ DEPENDENCIES
   redcarpet!
   sass
   slim (< 2.0)
+  sqlite3
   yard (~> 0.8.6.2)
-
-BUNDLED WITH
-   1.10.6

--- a/Rakefile
+++ b/Rakefile
@@ -103,6 +103,13 @@ namespace :generate do
   task :default => 'all'
 end
 
+desc "Generate the Dash docset"
+task :docset do
+  require 'docset'
+  sh "BUILDING_DOCSET=1 bundle exec middleman build --clean"
+  generate_docset
+end
+
 # Helpers
 #-----------------------------------------------------------------------------#
 

--- a/config.rb
+++ b/config.rb
@@ -36,6 +36,10 @@ configure :development do
   activate :livereload
 end
 
+if ENV['BUILDING_DOCSET']
+  puts "Using .docset layout"
+  set :layout, "docset_layout"
+end
 
 helpers do
 

--- a/docset-Info.plist
+++ b/docset-Info.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>CFBundleIdentifier</key>
+        <string>CocoaPodsGuides</string>
+        <key>CFBundleName</key>
+        <string>CocoaPodsGuides</string>
+        <key>DocSetPlatformFamily</key>
+        <string>CocoaPodsGuides</string>
+        <key>isDashDocset</key>
+        <true/>
+        <key>dashIndexFilePath</key>
+        <string>./index.html</string>
+</dict>
+</plist>
+

--- a/lib/docset.rb
+++ b/lib/docset.rb
@@ -1,0 +1,110 @@
+require 'nokogiri'
+require 'open-uri'
+require 'sqlite3'
+
+PWD = Dir.pwd
+
+#
+# Create any of the default docset file structure that we may need
+#
+def reset_docs_dir
+  if Dir.exist? './CocoaPodsGuides.docset'
+    `rm -Rf ./CocoaPodsGuides.docset`
+  end
+  
+  `mkdir -p ./CocoaPodsGuides.docset/Contents/Resources/Documents`
+
+  # get icon.png file
+  `wget https://cocoapods.org/favicons/apple-touch-icon.png -O ./CocoaPodsGuides.docset/icon.png`
+
+  `cp ./docset-Info.plist ./CocoaPodsGuides.docset/Contents/Info.plist`
+end
+
+#
+# create the sqlite index
+#
+def create_sqlite_db
+  db_file = './CocoaPodsGuides.docset/Contents/Resources/docSet.dsidx'
+  if File.exist? db_file
+    File.delete db_file
+  end
+  db = SQLite3::Database.new db_file
+
+  db.execute 'CREATE TABLE searchIndex(id INTEGER PRIMARY KEY, name TEXT, type TEXT, path TEXT);'
+  db.execute 'CREATE UNIQUE INDEX anchor ON searchIndex (name, type, path);'
+  return db
+end
+
+#
+# Given an html file path, open it, parse it, clean it up,
+# and overwirte the existing file.
+#
+def cleanup_html(file)
+  original = File.open(file)
+  page = Nokogiri::HTML(original)
+  original.close
+
+  page.css('nav').each { |nav| nav.remove }  
+  page.css('footer').each { |footer| footer.remove }
+  page.css('.site_navigation').each { |nav| nav.remove }
+  page.css('.info-row').each { |row| row.remove }
+  
+  page.css('.guide .container h5 a').each { |link| puts link.to_s }
+
+  File.open(file, 'w') { |f| f.write(page.to_s) }
+  puts "saved cleaned up #{file}"
+end
+
+def extract_main_nav(file)
+  original = File.open(file)
+  page = Nokogiri::HTML(original)
+  original.close
+  
+  page.css('.guide .container h5 a').to_a
+end
+
+def generate_docset
+  # delete the old dir and setup a new one
+  reset_docs_dir
+  
+  db = create_sqlite_db
+  
+  docset_dir = './CocoaPodsGuides.docset/Contents/Resources/Documents'
+
+  `mv build/** #{docset_dir}`
+  
+  Dir.chdir docset_dir
+
+  # grab the list of search commands to be used as the default page for splunk docs
+  cleanup_html("./index.html")
+  
+  links = extract_main_nav("./index.html")
+  
+  guide_pages = {}
+  links.each do |l|
+    guide_pages[l.text] = l.attributes["href"].value
+  end
+  
+  guide_pages.each do |page, url|
+    # cleanup the tail end of the URL using
+    path = './' + url.split('//').last
+    cleanup_html(path)
+    
+    # for each thing we want to link to, populate the sqlite index
+    db.execute "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('#{page}', 'Guide', '#{path}');"
+  end
+
+  Dir.chdir PWD
+
+  # # do any general cleanup inside the docset file structure
+  #
+  # f = File.open("list.html")
+  # doc = Nokogiri::HTML(f)
+  #
+  # links = doc.xpath('//a')
+  # sections = {}
+  #
+  # links.each do |l|
+  #   sections[l.text] = l.attribute('href').value
+  # end
+end

--- a/source/layouts/docset_layout.slim
+++ b/source/layouts/docset_layout.slim
@@ -1,0 +1,58 @@
+ruby:
+  parents = []
+  parent = current_resource
+  while parent = parent.parent
+    parents.unshift(parent)
+  end
+
+  topnav = []
+  for resource in sitemap.resources
+    if resource.ext == '.html' && resource.children.count > 0 && resource.parent != nil
+      topnav.unshift(resource)
+    end
+  end
+
+  footer_resources = sitemap.resources.select do |resource|
+    resource.data.footer
+  end.sort_by { |resource| resource.data.footer_order }
+
+  if current_resource.data.fullwidth || current_resource.parent == nil
+    width_classes = "content"
+  else
+    width_classes = "content col-md-10 col-md-offset-1 col-lg-10 col-lg-offset-1"
+  end
+
+doctype html
+html
+  head
+    title = "CocoaPods Guides - " + page_title
+
+    == shared_partial "favicons", "header_meta"
+    == stylesheet_link_tag "app.css"
+    == javascript_include_tag "application.js"
+
+  body
+
+    - unless current_resource.data.hide_title
+      section.container
+        .row
+          header.header class=width_classes
+            h1 == page_title
+
+      #content-wrapper.guide
+        section.container
+          .row
+            article class=width_classes
+              == yield
+
+              / Add support for external links in the headers of the guides
+              - if current_resource.data["external links"]
+                h2#external-resources <a class="header-link" href="#external-resources">&lt;</a> External resources
+
+                ul
+                  - for link in current_resource.data["external links"]
+                    li
+                      a href=link.values.first =link.keys.first
+    - else
+
+      == yield


### PR DESCRIPTION
Still a WIP, but good enough to share.

- added `rake docset` command
- added a docset specific layout that removes extra elements (e.g. nav, footers, analytics)
- added sqlite3 as a required gem (for creating sqlite index)
- added a default Info.plist that goes into the root of the docset
- use of an env variable BUILDING_DOCSET=1 to indicate the docset layout should be used
- builds a very basic index

Todo:

- [ ] parse `Podfile` and `podspec` reference items instead of guide items
- [ ] add anchor links to long pages to allow for jumping
- [ ] simplify layout where appropriate
- [ ] add version identifier (what version of guides or CP is this based on)
