### PR TITLE
Availability support for CocoaPods commands

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -86,7 +86,7 @@ begin
       require 'doc'
       puts "\e[1;33mBuilding Commands Data\e[0m"
       lib = Gem.loaded_specs['cocoapods'].full_require_paths.first
-      files = FileList[File.join(lib, 'lib/cocoapods/command/*.rb')]
+      files = FileList[File.join(lib, 'cocoapods/command/*.rb')]
       generator = Pod::Doc::Generators::Commands.new(files)
       generator.output_file = "docs_data/commands.yaml"
       generator.save

--- a/Rakefile
+++ b/Rakefile
@@ -85,8 +85,11 @@ begin
     task :commands do
       require 'doc'
       puts "\e[1;33mBuilding Commands Data\e[0m"
-      lib = Gem.loaded_specs['cocoapods'].full_require_paths.first
-      files = FileList[File.join(lib, 'cocoapods/command/*.rb')]
+      lib_paths = %w[cocoapods cocoapods-deintegrate cocoapods-search].map do |w|
+        Gem.loaded_specs[w].full_require_paths.first
+      end
+
+      files = lib_paths.map { |l| FileList[File.join(l, 'cocoapods*/command/*.rb')] }.flatten
       generator = Pod::Doc::Generators::Commands.new(files)
       generator.output_file = "docs_data/commands.yaml"
       generator.save

--- a/lib/doc/code_objects.rb
+++ b/lib/doc/code_objects.rb
@@ -187,6 +187,16 @@ module Pod
         #
         attr_accessor :tags
 
+        # @return [String] Version of CocoaPods when the command was added.
+        #
+        def available_since
+          if tags
+            if since = tags.select { |t| t.tag_name == "since" }.first
+              since.text
+            end
+          end
+        end
+
       end
 
 

--- a/lib/doc/code_objects.rb
+++ b/lib/doc/code_objects.rb
@@ -183,6 +183,10 @@ module Pod
         #
         attr_accessor :parent_options
 
+        # @return [Array<YARD::Tags::Tag>] YARD tags.
+        #
+        attr_accessor :tags
+
       end
 
 

--- a/lib/doc/generators/commands.rb
+++ b/lib/doc/generators/commands.rb
@@ -153,6 +153,8 @@ module Pod
           subcommand = CodeObjects::SubCommand.new
           subcommand.name = claide_subcommand.full_command
           subcommand.html_description = description(claide_subcommand)
+          registry = yard_registry.at(claide_subcommand.to_s)
+          subcommand.tags = registry.tags if registry
           # FIXME
           # puts claide_subcommand.name
           # puts  claide_subcommand.options

--- a/source/templates/commands.html.slim
+++ b/source/templates/commands.html.slim
@@ -51,6 +51,12 @@ ruby:
         h2
           = command.name
 
+        - if command.available_since
+          h5
+            = "Available since v#{command.available_since}."
+        br
+
+
         == link_doc_string command.html_description
 
         - unless command.options.empty?


### PR DESCRIPTION
Closes #110.

This pushes YARD tags for Commands into the docs. For example, 

<img width="285" alt="screen shot 2016-04-27 at 5 00 40 pm" src="https://cloud.githubusercontent.com/assets/466674/14868181/58030d40-0c9a-11e6-8038-730318340601.png">
Adding the `# @since` annotation to Deintegrate, 

<img width="1186" alt="screen shot 2016-04-27 at 5 00 10 pm" src="https://cloud.githubusercontent.com/assets/466674/14868198/6b3c5a10-0c9a-11e6-8d56-3c63a3469285.png">
