### PR TITLE
[Rakefile] Load subcommands into YARD

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -87,7 +87,7 @@ begin
       puts "\e[1;33mBuilding Commands Data\e[0m"
       libs = %w[cocoapods cocoapods-deintegrate cocoapods-search cocoapods-trunk cocoapods-try]
       lib_paths = libs.map { |w| Gem.loaded_specs[w].full_require_paths.first }
-      files = lib_paths.map { |l| FileList[File.join(l, '*/command/*.rb')] }.flatten
+      files = lib_paths.map { |l| FileList[File.join(l, '*/command/**/*.rb')] }.flatten
       generator = Pod::Doc::Generators::Commands.new(files)
       generator.output_file = "docs_data/commands.yaml"
       generator.save


### PR DESCRIPTION
Forgot that the subcommands are nested another level deep. Now this loads trunk, ipc, etc.
<img width="461" alt="screen shot 2016-05-14 at 6 09 08 pm" src="https://cloud.githubusercontent.com/assets/466674/15270917/f9a0e0ac-19fe-11e6-82c7-bd277434440d.png">
