### PR TITLE
Use a more determinate ordering system for the guides

### DIFF
--- a/source/contributing/dev-environment.html.md
+++ b/source/contributing/dev-environment.html.md
@@ -1,7 +1,7 @@
 ---
 title: Setting up for Development
 description: If you're looking to contribute to the CocoaPods project through feature additions or bug fixes, follow these instructions on setting up your development environment.
-order: 2
+order: 3
 ---
 
 CocoaPods is a collection of ruby gems. It is possible to clone them individually and set up a bundler environment for working in CocoaPods. However, for someone new to high-level library development in ruby this comes with a high learning curve. Because of this we will be using this guide to show how to set up using the [CocoaPods Rainforest](https://github.com/CocoaPods/Rainforest).

--- a/source/contributing/tickets-handling.html.md
+++ b/source/contributing/tickets-handling.html.md
@@ -1,7 +1,7 @@
 ---
 title: Ticket handling
 description: The easiest way to contribute is to help us handling the tickets.
-order: 4
+order: 5
 ---
 
 ## Tickets

--- a/source/making/getting-setup-with-trunk.html.md
+++ b/source/making/getting-setup-with-trunk.html.md
@@ -1,6 +1,6 @@
 ---
 title: Getting setup with Trunk
-order: 3
+order: 2
 description: Instructions for creating a CocoaPods user account
 
 ---

--- a/source/making/private-cocoapods.html.md
+++ b/source/making/private-cocoapods.html.md
@@ -1,7 +1,7 @@
 ---
 title: Private Pods
 description: How to setup a private Podspec repo for maintaining internal libraries.
-order: 3
+order: 4
 external links:
 -
   "Using CocoaPods to Modularise a Big iOS App by @aroldan": http://dev.hubspot.com/blog/architecting-a-large-ios-app-with-cocoapods

--- a/source/making/quality-indexes.html.md
+++ b/source/making/quality-indexes.html.md
@@ -1,7 +1,7 @@
 ---
 title: Quality Indexes
 description: Increasing your CocoaPod's Search Rank
-order: 4
+order: 3
 layout: quality_indexes
 see: https://github.com/CocoaPods/cocoadocs-api/blob/master/quality_modifiers.rb
 ---

--- a/source/making/specs-and-specs-repo.html.md
+++ b/source/making/specs-and-specs-repo.html.md
@@ -1,7 +1,7 @@
 ---
 title: Specs and the Specs Repo
 description: Learn about creating Podspec's and the Spec repo.
-order: 1
+order: 5
 ---
 
 A Podspec, or Spec, describes a version of a Pod library. One Pod, over the course of time, will have many Specs. It includes details about where the source should be fetched from, what files to use, the build settings to apply, and other general metadata such as its name, version, and description.


### PR DESCRIPTION
Looks like there was a bunch of duplicates in the ordering, so any change to the site would shuffle a few of the footer links - https://github.com/CocoaPods/guides.cocoapods.org/commit/4ee8dfe9d423f1ddc618994abcc8a349879a259b