### PR TITLE
Highlight useful & popular plugins from the community

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,6 +15,9 @@ task :bootstrap do
 
   puts "Creating data dir"
   execute_command "mkdir -p docs_data"
+
+  puts "Downloading Plugins JSON"
+  execute_command "curl https://raw.githubusercontent.com/CocoaPods/cocoapods-plugins/master/plugins.json --output docs_data/plugins.json"
 end
 
 begin

--- a/source/index.html.slim
+++ b/source/index.html.slim
@@ -23,8 +23,10 @@ ruby:
     resource.data.footer
   end.sort_by { |resource| resource.data.footer_order }
 
-  # Take out the contributing to CocoaPods to put below the main guide layout
+  # Take out the contributing + plugins to CocoaPods to put below the main guide layout
   contributing = footer_resources.pop
+  
+  plugins = footer_resources.pop
 
 
 section.container
@@ -45,7 +47,7 @@ div.guide#content-wrapper
 
           h2.guide-index == link_to page_title(resource), "/#{resource.destination_path}"
           ul
-            - for child in resource.children.sort_by{|child| child.data.order}
+            - for child in resource.children.sort_by{|child| child.data.order }
               - unless child.data.ignore
                 li
                     h5 == link_to( page_title(child), "/#{child.destination_path}")
@@ -76,6 +78,17 @@ div.guide#content-wrapper
 
             p Find out all of the supported terminal flags and commands.
 
+
+      .clearfix
+      .col-lg-12.col-sm-12.col-xs-12
+        h2.guide-index CocoaPods Plugins
+
+      .col-lg-12.col-sm-12.col-xs-12
+        - for child in plugins.children.sort_by{|child| child.data.order}
+          - unless child.data.ignore
+            .col-lg-4.col-sm-4.col-xs-12
+                h5 == link_to( page_title(child), "/#{child.destination_path}")
+                p == child.data.description
 
       .clearfix
       .col-lg-12.col-sm-12.col-xs-12

--- a/source/layouts/layout.slim
+++ b/source/layouts/layout.slim
@@ -98,12 +98,13 @@ html
             - if footer_resources.index(resource) % 2 == 1
               div.clearfix.visible-xs
 
-          .col-lg-3.col-sm-3.col-xs-6.footer-index
+          .clearfix
+          .col-xs-12.footer-index
             h3  <a href='/reference.html'>Reference</a>
             ul
-              li <a href='/syntax/podfile.html'>Podfile Syntax</a>
-              li <a href='/syntax/podspec.html'>Podspec Syntax</a>
-              li <a href='/terminal/commands.html'>Command-line Reference</a>
+              li.col-lg-3.col-sm-3.col-xs-6 <a href='/syntax/podfile.html'>Podfile Syntax</a>
+              li.col-lg-3.col-sm-3.col-xs-6 <a href='/syntax/podspec.html'>Podspec Syntax</a>
+              li.col-lg-3.col-sm-3.col-xs-6 <a href='/terminal/commands.html'>Command-line Reference</a>
 
     == shared_partial "footer"
 

--- a/source/making/index.html.md
+++ b/source/making/index.html.md
@@ -1,5 +1,5 @@
 ---
-title: Making CocoaPods
+title: Build with CocoaPods
 layout: index
 
 footer: yes

--- a/source/making/quality-indexes.html.md
+++ b/source/making/quality-indexes.html.md
@@ -4,4 +4,5 @@ description: Increasing your CocoaPod's Search Rank
 order: 3
 layout: quality_indexes
 see: https://github.com/CocoaPods/cocoadocs-api/blob/master/quality_modifiers.rb
+ignore: true
 ---

--- a/source/plugins/environment-vars.html.md
+++ b/source/plugins/environment-vars.html.md
@@ -1,0 +1,36 @@
+---
+title: Keeping Secrets
+description: Using cocoapods-keys to keep secrets out of your source
+order: 1
+---
+
+## The Problem
+
+You want to keep secrets like API access tokens outside of your source code. This is considered a good 
+engineering practice in general ([least privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege)) and 
+you may want to have different environments like staging and production.
+
+## The answer
+
+CocoaPods Keys adds a few commands, and uses the installation hooks:
+
+- `bundle exec pod keys set ARKeyName value` - lets you store a value in your computer's keychain 
+- `bundle exec pod keys get ARKeyName` - prints out the value from your computer's keychain
+
+Then inside your `Podfile`, add the plugin section. Noting the name of the `project`, the `target` to attach the pod
+to, and the keys that you want to use:
+
+```ruby
+plugin 'cocoapods-keys',
+       project: 'Artsy',
+       target: 'Artsy',
+       keys: [
+         'ArtsyAPIClientSecret',      # Auth for the Artsy API
+         'ArtsyAPIClientKey',         #
+         'ArtsyFacebookAppID',        # Supporting FB Login
+       ]
+```
+
+When you run `bundle exec pod install`, CocoaPods Keys will add a new Pod that has all of of your keys embedded inside it.
+
+To find out more, check out [`orta/cocoapods-keys`](https://github.com/orta/cocoapods-keys).

--- a/source/plugins/index.html.md
+++ b/source/plugins/index.html.md
@@ -1,0 +1,8 @@
+---
+title: Plugins
+layout: index
+footer: yes
+footer_order: 3
+---
+
+<p> Check out how CocoaPods Plugins works, or get an overview of some high profile plugins.</p>

--- a/source/plugins/optimising-ci-times.html.md
+++ b/source/plugins/optimising-ci-times.html.md
@@ -1,0 +1,23 @@
+---
+title: Optimise CI
+description: Using cocoapods-check to reduce work on CI
+order: 2
+---
+
+## The Problem
+
+`pod install` can take some time to complete, and if you have your `Pods` directory cached - sometimes you don't need to run it again for the current CI run. 
+
+This is the problem that [the Square team](https://github.com/square) addressed with the [plugin CocoaPods Check](https://github.com/square/cocoapods-check). 
+
+## The answer
+
+CocoaPods Check adds a command `pod check`, which will return with an error code of not zero if you need to run `pod install`. This means that you can run:
+
+```sh
+bundle exec pod check || bundle exec pod install
+```
+
+In your CI instead of just `bundle exec pod install` and you will get faster CI builds.
+
+To find out more, check out [`square/cocoapods-check`](https://github.com/square/cocoapods-check).

--- a/source/plugins/pre-compiling-dependencies.html.md
+++ b/source/plugins/pre-compiling-dependencies.html.md
@@ -1,0 +1,37 @@
+---
+title: Pre-compiling dependencies
+description: Using cocoapods-binary to pre-compile a set of your pods
+order: 2
+---
+
+## The Problem
+
+Even though you haven't made any changes to the Pods in your project, Xcode can still re-compile you libraries, even 
+when it should not need to do this. For a few small libraries this can be a small irritant, in a large project 
+this can be time-consuming and annoying.
+
+## The answer
+
+One solution for this is to not give Xcode the chance to re-compile code. CocoaPods Binary will pre-compile your Pods during 
+`pod install`, and then add the binary assets (e.g. `.framework` files) into the generated Xcode projects instead of the source code. 
+
+CocoaPods Binary works by adding a pre-install phase which:
+
+- Pulls out pods which you specify to be pre-compiled
+- Compiles those pods
+- Switches the Podspecs which used to refer to source code, to refer to the new compiled frameworks
+
+To specify which Pods you want to convert, edit your `Podfile` by appending `:binary => true` to your `pod` definitions.
+
+<pre><code>  plugin 'cocoapods-binary'
+  use_frameworks!
+
+  target "HP" do
+-      pod "ExpectoPatronum"
++      pod "ExpectoPatronum", :binary => true
+  end
+</code></pre>
+
+Then run `bundle exec pod install`.
+
+To find out more, check out [`leavez/cocoapods-binary`](https://github.com/leavez/cocoapods-binary).

--- a/source/plugins/setting-up-plugins.html.slim
+++ b/source/plugins/setting-up-plugins.html.slim
@@ -1,0 +1,74 @@
+---
+title: How to use CocoaPods plugins
+description: Understand how a CocoaPods plugin works and how to use them in your projects
+order: 0
+---
+
+markdown: 
+  ## CocoaPods + Plugins
+
+  CocoaPods is a community project run by very few maintainers with a massive surface area to maintain. It's safe to say 
+  that CocoaPods could never support every feature that Xcode supports, and even then the team has to say "no" to a lot of
+  potentially useful features.
+
+  Rather than let that be the end of the discussion, back in [2013 CocoaPods added support](https://blog.cocoapods.org/CocoaPods-0.28/) for CocoaPods Plugins. 
+  The plugin architecture allowed others to extend CocoaPods to support features that don't fit the main goal of dependency
+  management and eco-system growth.
+
+  ### What can CocoaPods Plugins do?
+
+  A CocoaPods Plugin can:
+
+  - Hook into the install process, both before and after
+  - Add new commands to `pod`
+  - Do whatever they want, because Ruby is a very dynamic language
+
+  This means the scope of a plugin is generally related to adding features to your build process, but can really do anything
+  you want. For example [`cocoapods-roulette`](https://github.com/sirlantis/cocoapods-roulette) generates a new iOS app
+  with three random Pods. We keep a relatively curated list of all plugins, you can see them at the end of this article.
+
+  ### How do I install a plugin
+
+  You will want to use a `Gemfile`, if you've never used a Gemfile before or want a refresher - check out our guide
+  ["Using a Gemfile"](/using/a-gemfile.html). All CocoaPods Plugins are Gems, and they are installed by first adding 
+  them to the `Gemfile`, then you need to mention that they exist inside your Podfile. 
+
+  For example, to use [cocoapods-repo-update](https://github.com/wordpress-mobile/cocoapods-repo-update) - you need to 
+  amend your `Gemfile`:
+
+  <pre><code>  source 'https://rubygems.org'
+
+    gem 'cocoapods'
+  + gem 'cocoapods-repo-update'
+    gem 'fastlane'
+  </code></pre>
+
+  Then add a reference to it in your `Podfile`:
+
+  <pre><code>  platform :ios, '9.0'
+  + plugin 'cocoapods-repo-update'
+
+    use_frameworks!
+
+    # OWS Pods
+    pod 'SignalCoreKit', git: 'https://github.com/signalapp/SignalCoreKit.git', testspecs: ["Tests"]
+  </code></pre>
+
+  Running `bundle exec pod install` will then have the `cocoapods-repo-update` plugin executed also.
+
+  ### What Plugins Exist?
+
+  There's quite a few! If you have some more to add, send us a PR to [this JSON file](https://github.com/CocoaPods/cocoapods-plugins/blob/master/plugins.json)
+
+- json = JSON.parse(File.read "docs_data/plugins.json")
+- plugins = json["plugins"].sort_by { |p| p["name"] }
+
+</div></div>
+
+div style="padding: 20px; flex-wrap: wrap; display: flex;"
+  - plugins.each do |plugin|
+    div style='width: 25%; padding: 20px;' 
+    
+      h4
+        a href=plugin["url"] = plugin["name"]
+      p = plugin["description"]

--- a/source/plugins/using-pods-for-closed-source-libs.html.md
+++ b/source/plugins/using-pods-for-closed-source-libs.html.md
@@ -1,0 +1,24 @@
+---
+title: Packaging Closed Source SDKs
+description: Using cocoapods-packager to ship closed source Pods
+order: 4
+---
+
+## The Problem
+
+You need to write an SDK that is closed source, but you'd like to use dependencies. Due to the limitations of the 
+process runtime, you can only have one version of a dependency in an app. If your closed-source SDK happens to include 
+the same dependencies as another then your SDK consumers are not going to have a good time.
+
+## The answer
+
+CocoaPods Packager is a `pod` command that takes a Podspec and generates the resulting framework or static library for
+you. It has techniques for embedding it's dependencies safely and uses a Podspec as the source of truth for all your 
+settings.
+
+
+```sh
+bundle exec pod package ORStackView.podspec
+```
+
+To find out more, check out [`cocoapods/cocoapods-packager`](https://github.com/cocoapods/cocoapods-packager).

--- a/source/using/a-gemfile.html.md
+++ b/source/using/a-gemfile.html.md
@@ -2,8 +2,6 @@
 title: Using a Gemfile
 description: Find out how you can use a Gemfile to version your ruby dependencies
 order: 6
-ignore: true
-
 ---
 
 ## RubyGems + Bundler


### PR DESCRIPTION
I was thinking about how I didn't know that CocoaPods Binary didn't exist in  https://github.com/signalapp/Signal-iOS/pull/4096 and came to the conclusion that there must be a lot of plugins people don't know about.

This adds a 5th section of docs to the guides: Being a consumer, being a producer, API reference, contributing back to CP and now plugins.

I did some re-balancing of the UI a bit to make the section fit, and it feels reasonable to me 👍  