### PR TITLE
Remove dead link in `specs-and-specs-repo` page

### DIFF
--- a/source/making/specs-and-specs-repo.html.md
+++ b/source/making/specs-and-specs-repo.html.md
@@ -105,7 +105,7 @@ CocoaPods installations.
 When you are preparing a podspec for submission, you should make sure to do the following:
 
 1. Run `pod spec lint`. This is used to validate specifications. Your podspec should pass without any errors or warnings.
-2. Update your library to use [Semantic Versioning](http://semver.org/), if it already does not follow that scheme. See our [wiki on cross dependency resolution](https://github.com/CocoaPods/Specs/wiki/Cross-dependencies-resolution-example) for more details. Essentially it makes everyone's life easier.
+2. Update your library to use [Semantic Versioning](http://semver.org/), if it already does not follow that scheme. Essentially it makes everyone's life easier.
 3. Make sure any updates you submit do not break previous installations.
 4. Perform manual testing of your Podspec by [including the local Podspec](/syntax/podfile.html#pod) in the Podfile of a real application and/or your demo application, and ensuring it works as expected. **You alone** are responsible for ensuring your Podspec functions properly for your users.
 


### PR DESCRIPTION
Closes #147

We could potentially add more context here, but for now removing the dead link seems worthwhile.