### PR TITLE
Add concurrent-ruby gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,8 @@ gem 'pygments.rb', '~> 0.6.0'
 gem 'github-markup'
 gem 'nokogiri'
 
+gem 'concurrent-ruby'
+
 gem 'cocoapods', '> 0.a'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,7 @@ GEM
       sass (>= 3.3.0, < 3.5)
     compass-import-once (1.0.5)
       sass (>= 3.2, < 3.5)
+    concurrent-ruby (1.1.5)
     dotenv (0.11.1)
       dotenv-deployment (~> 0.0.2)
     dotenv-deployment (0.0.2)
@@ -223,6 +224,7 @@ PLATFORMS
 DEPENDENCIES
   activesupport
   cocoapods (> 0.a)
+  concurrent-ruby
   foreman
   github-markup
   middleman


### PR DESCRIPTION
This will fix guides for 1.8.0.beta.1. It can be removed in beta2 where the Core gem properly specifies this dependency as added here https://github.com/CocoaPods/Core/pull/577