### PR TITLE
Remove the <span>v1.8.0</span> from HTML head title

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -58,8 +58,8 @@ end
 
 navigation_data = {
   'dsl' => [
-    { :name => "podfile", :title => "Podfile Syntax Reference <span>v#{Pod::VERSION}</span>" },
-    { :name => "podspec", :title => "Podspec Syntax Reference <span>v#{Pod::VERSION}</span>" },
+    { :name => "podfile", :title => "Podfile Syntax Reference" },
+    { :name => "podspec", :title => "Podspec Syntax Reference" },
   ],
 }
 
@@ -71,7 +71,7 @@ navigation_data['dsl'].each do |dsl|
   name = dsl[:name]
   title = dsl[:title]
   proxy "syntax/#{name}.html", "templates/dsl.html", {
-    :locals => { :name => name, :page_title => title, :fullwidth => true },
+    :locals => { :name => name, :page_browser_title => title, :page_title => title + " <span>v#{Pod::VERSION}</span>", :fullwidth => true },
     :ignore => true,
   }
 end

--- a/source/layouts/layout.slim
+++ b/source/layouts/layout.slim
@@ -25,7 +25,7 @@ ruby:
 doctype html
 html
   head
-    title = "CocoaPods Guides - " + page_title
+    title = "CocoaPods Guides - " + page_browser_title || page_title
 
     == shared_partial "favicons", "header_meta"
     == stylesheet_link_tag "app.css"


### PR DESCRIPTION
Solves the strange titles of the DSL Guides.