### PR TITLE
Fix footer bundle index of Contributing

### DIFF
--- a/source/contributing/index.html.slim
+++ b/source/contributing/index.html.slim
@@ -3,7 +3,7 @@ title: Contributing
 layout: index
 
 footer: yes
-footer_order: 3
+footer_order: 4
 ---
 
 p 


### PR DESCRIPTION
I find that at the home page: https://guides.cocoapods.org/
CocoaPods Plugins   And  Contributing Back   content is reverse wrong. I try to fix it.   Please test and update!!