### PR TITLE
Fix URL to the Artsy CocoaPods specs repository

### DIFF
--- a/source/making/private-cocoapods.html.md
+++ b/source/making/private-cocoapods.html.md
@@ -80,7 +80,7 @@ $ git init --bare
 > Using the URL of your repo on your server, add your repo using
 
 ```shell
-$ pod repo add artsy-specs git@github:artsy/Specs.git
+$ pod repo add artsy-specs https://github.com/artsy/Specs.git
 ```
 
 > Check your installation is successful and ready to go:


### PR DESCRIPTION
Changes the URL to the [Artsy CocoaPods specs repository](https://github.com/artsy/Specs) from `git@github:artsy/Specs.git` to `https://github.com/artsy/Specs.git`.

```console
$ pod repo add artsy-specs git@github:artsy/Specs.git
Cloning spec repo `artsy-specs` from `git@github:artsy/Specs.git`
[!] /usr/bin/git clone git@github:artsy/Specs.git -- artsy-specs

Cloning into 'artsy-specs'...
ssh: Could not resolve hostname github: nodename nor servname provided, or not known
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.

```