### PR TITLE
Update private-cocoapods.html.md to point to a specific commit

### DIFF
--- a/source/making/private-cocoapods.html.md
+++ b/source/making/private-cocoapods.html.md
@@ -138,7 +138,7 @@ pod repo push artsy-specs ~/Desktop/Artsy+OSSUIFonts.podspec
             └── Artsy+OSSUIFonts.podspec
 ```
 
-> See this [Podfile](https://github.com/artsy/eigen/blob/master/Podfile) for an example of how the repo URL is included
+> See this [Podfile](https://github.com/artsy/eigen/blob/eae3a631d35da68af7be2f3296235d41cce6fe1b/Podfile) for an example of how the repo URL is included
 
 ## How to remove a Private Repo
 


### PR DESCRIPTION
We will be removing this soon, and I noticed that the link is to master, so better to point to a current commit :)