### PR TITLE
Correct the order of the articles in the `using` folder.

### DIFF
--- a/source/using/a-gemfile.html.md
+++ b/source/using/a-gemfile.html.md
@@ -1,7 +1,7 @@
 ---
 title: Using a Gemfile
 description: Find out how you can use a Gemfile to version your ruby dependencies
-order: 6
+order: 7
 ---
 
 ## RubyGems + Bundler

--- a/source/using/faq.html.md
+++ b/source/using/faq.html.md
@@ -1,7 +1,7 @@
 ---
 title: F.A.Q
 description: Is CocoaPods ready for prime-time? Why not just use git submodules? etc. etc.
-order: 4
+order: 5
 ---
 
 ### "Will CocoaPods stop development now that Swift has a built-in package manager?"

--- a/source/using/pod-install-vs-update.html.md
+++ b/source/using/pod-install-vs-update.html.md
@@ -1,7 +1,7 @@
 ---
 title: pod install vs. pod update
 description: Explains the difference between pod install and pod update and when to use each
-order: 1
+order: 2
 ---
 
 ## Introduction

--- a/source/using/test-specs.html.md
+++ b/source/using/test-specs.html.md
@@ -1,7 +1,7 @@
 ---
 title: Testing with CocoaPods
 description: This is a guide for working with test specifications and CocoaPods
-order: 5
+order: 6
 ---
 
 ## Test Specifications

--- a/source/using/the-podfile.html.md
+++ b/source/using/the-podfile.html.md
@@ -1,7 +1,7 @@
 ---
 title: The Podfile
 description: Learn all about the Podfile, which is used to declare dependencies for your project.
-order: 2
+order: 3
 external links:
   - "Non-trivial Podfile in Artsy/Eigen": https://github.com/artsy/eigen/blob/master/Podfile
   - "Podfile for a Swift project in Artsy/Eidolon": https://github.com/artsy/eidolon/blob/master/Podfile

--- a/source/using/troubleshooting.html.md
+++ b/source/using/troubleshooting.html.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting
 description: The solutions to common problems.
-order: 3
+order: 4
 ---
 
 ### Installing CocoaPods

--- a/source/using/unreleased-features.html.md
+++ b/source/using/unreleased-features.html.md
@@ -2,7 +2,7 @@
 title: Using Unreleased Features
 description: Instructions to use CocoaPods from a feature branch or a Work-in-progress fork
 ignore: true
-order: 0
+order: 8
 thanks: "Sachin Palewar"
 ---
 


### PR DESCRIPTION
# Current issue

As we can see in `using/unreleased-features.html.md`, the order of this article is `0`, which is must wrong:
```
---
title: Using Unreleased Features
description: Instructions to use CocoaPods from a feature branch or a Work-in-progress fork
ignore: true
order: 0
thanks: "Sachin Palewar"
---
```

This wrong order number lead to the position of this article is too front:

<img width="1049" alt="Screen Shot 2022-05-18 at 01 05 47" src="https://user-images.githubusercontent.com/12227130/168871610-39611789-30d0-4fb3-85a5-fed2554a805d.png">

Current order number of articles in `using` folder is here, there are two _repetitive_ items:

| article  |  order |
|---|---|
| getting-started.html   | 0  |
|  unreleased-features.html |  0 |
|  using-cocoapods.html |  1 |
| pod-install-vs-update.html  | 1 |
| the-podfile.html  | 2 |
| troubleshooting.html  | 3 |
| faq.html 	 | 4 |
| test-specs.html  | 5 |
| a-gemfile.html  | 6 |

# Re-numbering

I think `unreleased-features.html` should move to the last position, and `pod-install-vs-update.html` should use number `2`, so the following articles' order number should all add `1` .

| article  |  order |
|---|---|
| getting-started.html   | 0  |
| using-cocoapods.html |  1 |
| pod-install-vs-update.html  | 2 |
| the-podfile.html  | 3 |
| troubleshooting.html  | 4 |
| faq.html 	 | 5 |
| test-specs.html  | 6 |
| a-gemfile.html  | 7 |
| unreleased-features.html |  8 |

After changed these order, I can see a better order for these articles (I run the website locally):

<img width="1064" alt="image" src="https://user-images.githubusercontent.com/12227130/168875384-6ad27e0a-0c9c-4f34-a337-f6c38f7072b7.png">


