### PR TITLE
Update the link to the claims form in guide "Getting setup with trunk".

### DIFF
--- a/source/making/getting-setup-with-trunk.html.md
+++ b/source/making/getting-setup-with-trunk.html.md
@@ -49,4 +49,4 @@ This will then list all the known library owners. Note: they need to already hav
 
 ### Claiming an existing library
 
-If you want to claim a library that someone has already claimed, then you can use [our Claims form](https://trunk.cocoapods.org/claims/new) to say that you are the owner or maintainer of a collection of libraries. Any issues regarding ownership of libraries will be arbitrated by the CocoaPods dev team.
+If you want to claim a library that someone has already claimed, then you can use [our Claims form](https://trunk.cocoapods.org/disputes) to say that you are the owner or maintainer of a collection of libraries. Any issues regarding ownership of libraries will be arbitrated by the CocoaPods dev team.


### PR DESCRIPTION
Updated the url to the claims form from "https://trunk.cocoapods.org/claims/new" to "https://trunk.cocoapods.org/disputes". This is the new location of the form as per the comment of Orta [here](https://github.com/CocoaPods/CocoaPods/issues/12150).