### PR TITLE
Fixes the URL to dispute form

### DIFF
--- a/source/making/getting-setup-with-trunk.html.md
+++ b/source/making/getting-setup-with-trunk.html.md
@@ -49,4 +49,4 @@ This will then list all the known library owners. Note: they need to already hav
 
 ### Claiming an existing library
 
-If you want to claim a library that someone has already claimed, then you can use [our Claims form](https://trunk.cocoapods.org/claims/new) to say that you are the owner or maintainer of a collection of libraries. Any issues regarding ownership of libraries will be arbitrated by the CocoaPods dev team.
+If you want to claim a library that someone has already claimed, then you can use [our Claims form](https://trunk.cocoapods.org/disputes/) to say that you are the owner or maintainer of a collection of libraries. Any issues regarding ownership of libraries will be arbitrated by the CocoaPods dev team.


### PR DESCRIPTION
The URL for claiming an existing pod leads to 404.

This tiny PR updates the URL to point towards https://trunk.cocoapods.org/disputes/